### PR TITLE
simplified the List implementation

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -1,92 +1,143 @@
 /// The list and events for handling movement within the list. No UI.
-use super::item::Item;
+use std::collections::VecDeque;
 
+/// # List
+///
+/// `List` represents a list of items and a selection of one from that list.
+/// To encode the selection, `List` maintains items in
+/// a queue `above` of items above the selection,
+/// a selected item which can be `Option::None` in case the list is empty, and
+/// a queue `below` of items below the selection.
+///
+/// For instance `above = [1, 2]`, `selected = Some(3)`, `below = [4, 5, 6]` results in the list
+/// - 1
+/// - 2
+/// - (3)
+/// - 4
+/// - 5
+/// - 6
+///
+/// Maintain the INVARIANT that `selected` can only be empty if there are no elements in the list.
 pub struct List<T>
 where
     T: Clone,
 {
-    pub top_index: u8,
-    pub bottom_index: u8,
-    pub lines_to_show: i8,
-    pub selected_index: i8,
-    pub items: Vec<Item<T>>,
+    capacity: usize,
+    above: VecDeque<T>,
+    selected: Option<T>,
+    below: VecDeque<T>,
 }
 
 impl<T> List<T>
 where
     T: Clone,
 {
-    pub fn new(lines_to_show: i8) -> Self {
+    pub fn new(capacity: usize) -> Self {
         List {
-            items: vec![],
-            top_index: lines_to_show as u8 - 1,
-            selected_index: (lines_to_show - 1) as i8,
-            lines_to_show,
-            bottom_index: 0,
+            capacity,
+            above: VecDeque::new(),
+            selected: None,
+            below: VecDeque::new(),
         }
     }
 
-    pub fn up(&mut self, matches: &[Item<T>]) {
-        let match_count = matches.len() as i8;
-        if self.selected_index > 0 {
-            self.selected_index -= 1;
-        } else if self.top_index < (match_count - 1) as u8 {
-            self.bottom_index += 1;
-            self.top_index += 1;
+    /// Items in order from top to bottom
+    pub fn items<'a>(&'a self) -> Box<dyn Iterator<Item = T> + 'a> {
+        Box::new(
+            self.above
+                .iter()
+                .chain(self.selected.iter())
+                .chain(self.below.iter())
+                .cloned(),
+        )
+    }
+
+    pub fn tagged_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (bool, T)> + 'a> {
+        let selected_index = self.len_above();
+        Box::new(
+            self.items()
+                .enumerate()
+                .map(move |(index, item)| (index == selected_index, item)),
+        )
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn len(&self) -> usize {
+        self.above.len() + self.selected.iter().count() + self.below.len()
+    }
+
+    pub fn len_above(&self) -> usize {
+        self.above.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // NOTE that because of the invariant the line below is equivalent to
+        //  `self.above.is_empty() && self.selected.is_none() && self.below.is_empty()`
+        self.selected.is_none()
+    }
+
+    pub fn up(&mut self) {
+        if let Some(item_above) = self.above.pop_back() {
+            if let Some(selected) = self.selected.take() {
+                self.below.push_front(selected);
+                self.selected = Some(item_above);
+            } else {
+                unreachable!("the invariant has been violated")
+            }
         }
-        self.floor_selected_index();
     }
 
     pub fn down(&mut self) {
-        // Should we move the selection down?
-        if self.selected_index < self.top_index as i8 {
-            self.selected_index += 1;
-        }
-
-        // Should we scroll down?
-        if self.selected_index > self.lines_to_show - 1 && self.bottom_index > 0 {
-            self.bottom_index -= 1;
-            self.top_index -= 1;
-            // if we've scrolled down then we don't want to change the selected index
-            // The selected index is for the view, so it stays the same.
-            if self.selected_index > 0 {
-                self.selected_index -= 1;
-            }
-        }
-        self.floor_selected_index();
-    }
-
-    fn floor_selected_index(&mut self) {
-        let index_of_first_blank = self.items.iter().rev().position(|item| item.is_blank);
-        if let Some(rev_index) = index_of_first_blank {
-            let index = self.lines_to_show - rev_index as i8;
-            if self.selected_index < index as i8 {
-                self.selected_index = index
+        if let Some(item_below) = self.below.pop_front() {
+            if let Some(selected) = self.selected.take() {
+                self.above.push_back(selected);
+                self.selected = Some(item_below);
+            } else {
+                unreachable!("the invariant has been violated")
             }
         }
     }
 
     /// Takes the current matches and updates the visible contents.
-    pub fn update(&mut self, matches: &[Item<T>]) {
+    ///
+    /// The input matches are assumed to be sorted in descending order of score.
+    pub fn update(&mut self, matches: &[T]) {
         log::info!("Updating view with {} match(es)", matches.len());
-        let mut to_render: Vec<Item<T>> = Vec::new();
-        // Get everything in our display window
-        for i in self.bottom_index..self.top_index + 1 {
-            if matches.len() > (i).into() {
-                to_render.push(matches[i as usize].clone());
-            } else {
-                to_render.push(Item::empty());
-            }
-        }
-        to_render.reverse();
+        let is_empty = self.is_empty();
+        let selected_len = self.selected.iter().count();
+        let below_len = self.below.len();
+        let above_len = self.capacity - selected_len - below_len;
+        assert_eq!(above_len + selected_len + below_len, self.capacity);
 
-        self.items = to_render;
-        self.floor_selected_index();
+        self.above.clear();
+        self.below.clear();
+        self.selected = None;
+
+        // take the highest scoring items
+        let iter = matches.iter().take(self.capacity as usize).cloned();
+
+        if is_empty {
+            // extend above so the bottom item gets selected if the List was initially empty
+            self.above.extend(iter.rev());
+        } else {
+            // otherwise fill up from below
+            self.below.extend(iter.clone().take(below_len).rev());
+            self.selected = iter.clone().nth(below_len);
+            self.above.extend(iter.skip(below_len + 1).rev());
+        }
+
+        // ensure invariant
+        if self.selected.is_none() {
+            // select the top-most item by default
+            self.selected = self.below.pop_front().or_else(|| self.above.pop_back());
+        }
     }
 
-    pub fn get_selected(&self) -> &Item<T> {
-        let index = self.selected_index as usize;
-        &self.items[index]
+    pub fn get_selected(&self) -> &T {
+        self.selected.as_ref().unwrap()
     }
 }
 
@@ -94,6 +145,7 @@ where
 mod tests {
 
     use super::*;
+    use super::super::item::Item;
 
     #[derive(Clone)]
     struct TestItem {
@@ -112,12 +164,12 @@ mod tests {
     struct Setup {
         items: Vec<Item<TestItem>>,
         few_items: Vec<Item<TestItem>>,
-        view: List<TestItem>,
+        view: List<Item<TestItem>>,
     }
 
     impl Setup {
         fn new(lines_to_show: i8) -> Self {
-            let view = List::<TestItem>::new(lines_to_show);
+            let view = List::<Item<TestItem>>::new(lines_to_show as usize);
 
             Setup {
                 items: vec![
@@ -150,8 +202,8 @@ mod tests {
         setup.view.update(&setup.items);
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8);
-        assert_eq!(setup.view.selected_index, 7); // 0-indexed
+        assert_eq!(setup.view.len(), 8);
+        assert_eq!(setup.view.len_above(), 7); // 0-indexed
         assert_eq!(setup.view.get_selected().item.as_ref().unwrap().name, "A")
     }
 
@@ -162,13 +214,13 @@ mod tests {
         setup.view.update(&setup.items);
 
         // WHEN
-        setup.view.up(&setup.items); // 6
-        setup.view.up(&setup.items); // 5
-        setup.view.up(&setup.items); // 4
+        setup.view.up(); // 6
+        setup.view.up(); // 5
+        setup.view.up(); // 4
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8);
-        assert_eq!(setup.view.selected_index, 4);
+        assert_eq!(setup.view.len(), 8);
+        assert_eq!(setup.view.len_above(), 4);
     }
 
     #[test]
@@ -176,26 +228,31 @@ mod tests {
         // GIVEN
         let mut setup = Setup::new(8);
         setup.view.update(&setup.items);
+        assert!(setup.items.len() > 0);
+        assert_eq!(
+            setup.view.len(),
+            setup.view.capacity().min(setup.items.len())
+        );
 
         // WHEN
         // More than lines_to_show
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
-        setup.view.up(&setup.items);
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
+        setup.view.up();
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8);
-        assert_eq!(setup.view.selected_index, 0);
+        assert_eq!(setup.view.len(), 8);
+        assert_eq!(setup.view.len_above(), 0);
     }
 
     #[test]
@@ -208,8 +265,8 @@ mod tests {
         setup.view.down(); // 7
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8);
-        assert_eq!(setup.view.selected_index, 7);
+        assert_eq!(setup.view.len(), 8);
+        assert_eq!(setup.view.len_above(), 7);
     }
 
     #[test]
@@ -219,14 +276,14 @@ mod tests {
         setup.view.update(&setup.items);
 
         // WHEN
-        setup.view.up(&setup.items); // 6
-        setup.view.up(&setup.items); // 5
-        setup.view.up(&setup.items); // 4
+        setup.view.up(); // 6
+        setup.view.up(); // 5
+        setup.view.up(); // 4
         setup.view.down(); // 5
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8);
-        assert_eq!(setup.view.selected_index, 5);
+        assert_eq!(setup.view.len(), 8);
+        assert_eq!(setup.view.len_above(), 5);
     }
 
     #[test]
@@ -236,13 +293,13 @@ mod tests {
 
         // WHEN
         setup.view.update(&setup.few_items);
-        setup.view.up(&setup.few_items); // 6
-        setup.view.up(&setup.few_items); // 5
-        setup.view.up(&setup.few_items); // 5
-        setup.view.up(&setup.few_items); // 5
+        setup.view.up(); // 6
+        setup.view.up(); // 5
+        setup.view.up(); // 5
+        setup.view.up(); // 5
 
         // THEN
-        assert_eq!(setup.view.items.len(), 8); // Still 8, but blanks
-        assert_eq!(setup.view.selected_index, 5);
+        assert_eq!(setup.view.len(), 3);
+        assert_eq!(setup.view.len_above(), 0);
     }
 }


### PR DESCRIPTION
As I investigated the source code in hope of fixing [a crash](https://github.com/jamescoleuk/fuzzy_finder/issues/1#issuecomment-1214485831), I found that the index based approach looked error-prone. So I tried to use something more [zipper-like](https://en.wikipedia.org/wiki/Zipper_(data_structure)).
While there are still things that can go wrong, the problems that appeared were easy to manage and it doesn't crash for me (for now 😅 ...)

Of course feel free to reject this approach, I'm just here to have a bit of fun with rust 😄 