### PR TITLE
Fix out of index error

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -60,9 +60,7 @@ where
         let index_of_first_blank = self.items.iter().rev().position(|item| item.is_blank);
         if let Some(rev_index) = index_of_first_blank {
             let index = self.lines_to_show - rev_index as i8;
-            if self.selected_index < index as i8 {
-                self.selected_index = index
-            }
+            self.selected_index = index
         }
     }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/46488521/190376736-3278ad9c-ca20-4ea1-8f2e-7ef6d853fc76.mov

If you search for words that do not match as you can see in attached video, there is a bug that the selected index is set incorrectly.
This is because in `floor_selected_index` at `list.rs`, `selected_index` is updated only when the new `index` is bigger than previous `selected_index`.

`rev_index` is set to `0` instead of `None` when none of items matches.
Therefore, `selected_index` becomes `6` and, of course, even if there is matching item afterward, it is not updated because it is always smaller than `selected_index`.